### PR TITLE
Adding Windows 10 Support + fix cold reboot issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,6 @@ Once you're done adding the device, make sure to disable it.  You can do this in
 pnputil /disable-device /deviceid root\iddsampledriver
 ```
 
-> [!NOTE]
-> Make sure the `C:\IddSampleDriver\option.txt` file exists (create it if it doesn't).
->
-> Open the file with notepad and write `1`, add a new line, save and close.
->
-> The custom resolutions/frame rates of your clients will automatically be updated in the file.
-
 ### Multi Monitor Tool
 
 Then, you'll need to download [MultiMonitorTool](https://www.nirsoft.net/utils/multi_monitor_tool.html) - make sure to place the extracted files in the same directory as the scripts.  These scripts assume that the multi-monitor-tool in use is the 64-bit version - if you need the 32 bit version, you'll need to edit this line for the correct path:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     It deactivates all the other monitors while streaming and activate them back when the stream is finished.
 </p>
 
+
 # Table of Contents
 - [Disclaimer](#disclaimer)
 - [Setup](#setup)
@@ -14,6 +15,7 @@
 - [Sunshine Setup](#sunshine-setup)
     - [UI](#ui)
     - [Config File](#config-file)
+
 
 ## Disclaimer
 
@@ -55,9 +57,11 @@ While I'm pretty confident this will not break your computer, I don't know enoug
     
     - If you already have a second monitor, disconnect it - similar to the point above, might result in getting signal back.
 
+
 ## Setup
 
 First, download the [latest release](https://github.com/LeGeRyChEeSe/sunshine-virtual-monitor/releases/latest) (`.zip` file) and unzip it.
+
 
 ### Virtual Display Driver
 
@@ -69,6 +73,7 @@ Once you're done adding the device, make sure to disable it.  You can do this in
 pnputil /disable-device /deviceid root\iddsampledriver
 ```
 
+
 ### Multi Monitor Tool
 
 Then, you'll need to download [MultiMonitorTool](https://www.nirsoft.net/utils/multi_monitor_tool.html) - make sure to place the extracted files in the same directory as the scripts.  These scripts assume that the multi-monitor-tool in use is the 64-bit version - if you need the 32 bit version, you'll need to edit this line for the correct path:
@@ -76,6 +81,7 @@ Then, you'll need to download [MultiMonitorTool](https://www.nirsoft.net/utils/m
 ```batch
 $multitool = Join-Path -Path $filePath -ChildPath "multimonitortool-x64\MultiMonitorTool.exe"
 ```
+
 
 ### Windows Display Manager
 
@@ -85,11 +91,13 @@ The powershell scripts use a module called [`WindowsDisplayManager`](https://git
 Install-Module -Name WindowsDisplayManager
 ```
 
+
 ### VSYNC Toggle
 
 This is used to turn off / restore vsync when the stream starts/ends.
 
 Just download [vsync-toggle](https://github.com/xanderfrangos/vsync-toggle/releases/latest) and put it in the same directory as the scripts.
+
 
 ## Sunshine Setup
 
@@ -97,6 +105,7 @@ In all the text below, replace `%PATH_TO_THIS_REPOSITORY%` with the full path to
 
 > [!NOTE]
 > The commands below will forward the scripts output to a file in this repository, named `sunvdm.log` - this is optional and can be removed if you don't care for logs / can be directed somewhere else.
+
 
 ### UI
 
@@ -107,29 +116,28 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 In the first text box the `config.do_cmd` column, you will write:
 
 ```batch
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% > "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
 ```batch
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\teardown_sunvdm.ps1" >> "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
 > [!WARNING]
-> Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
->
-> Make sure also to replace `%PATH_TO_THIS_REPOSITORY%` with the correct path to the folder containing the scripts.
+> Make sure to replace `%PATH_TO_THIS_REPOSITORY%` with the correct path to the folder containing the scripts.
 
 > [!NOTE]
 > You will also select the checkbox for `config.elevated` under the `config.run_as` column (we need to run as elevated in order to enable and disable the display device).
+
 
 ### Config File
 
 You can set the following in your `sunshine.conf` config file:
 
 ```batch
-global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
+global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -67,13 +67,21 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 In the first text box the `config.do_cmd` column, you will write:
 
 ```
+<<<<<<< HEAD
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
+=======
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
+>>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
 ```
+<<<<<<< HEAD
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
+=======
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
+>>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
@@ -85,7 +93,11 @@ You will also select the checkbox for `config.elevated` under the `config.run_as
 You can set the following in your `sunshine.conf` config file:
 
 ```
+<<<<<<< HEAD
 global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","elevated":"true"}]
+=======
+global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\"" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1\"","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\"" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
+>>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.

--- a/README.md
+++ b/README.md
@@ -67,21 +67,13 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 In the first text box the `config.do_cmd` column, you will write:
 
 ```
-<<<<<<< HEAD
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
-=======
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
->>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
 ```
-<<<<<<< HEAD
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
-=======
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
->>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
@@ -93,11 +85,7 @@ You will also select the checkbox for `config.elevated` under the `config.run_as
 You can set the following in your `sunshine.conf` config file:
 
 ```
-<<<<<<< HEAD
-global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","elevated":"true"}]
-=======
 global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\"" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1\"","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\"" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
->>>>>>> b172618 (Fix VDD name for every Windows configuration)
 ```
 
 If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,86 @@
-# Sunshine Automatic Virtual Monitor
+<h1 align='center'>Sunshine Virtual Monitor</h1>
+<p align="center">
+    Sunshine Virtual Monitor provides a way to automatically enable a <b>dedicated Virtual Display Monitor</b> for your Sunshine Streaming Sessions.<br>
+    It deactivates all the other monitors while streaming and activate them back when the stream is finished.
+</p>
 
-This repository stores and documents scripts for automatically setting up a virtual display monitor for sunshine, blacking out the host computer displays, and then tearing down the new screen, and undoing turning off the displays.
+# Table of Contents
+- [Disclaimer](#disclaimer)
+- [Setup](#setup)
+    - [Virtual Display Driver](#virtual-display-driver)
+    - [Multi Monitor Tool](#multi-monitor-tool)
+    - [Windows Display Manager](#windows-display-manager)
+    - [VSYNC Toggle](#vsync-toggle)
+- [Sunshine Setup](#sunshine-setup)
+    - [UI](#ui)
+    - [Config File](#config-file)
 
-## Warning
+## Disclaimer
 
-This should be considered BETA - it is working well for me, but at the time of writing this no one else has tested it so far.
+> [!CAUTION]
+> This should be considered **BETA** - it is working well for me, but at the time of writing this no one else has tested it so far.
 
-While I'm pretty confident this will not break your computer, I don't know enough about Windows Drivers to be 100% sure.  Further, there is a real risk that your displays won't come back after a streaming sesion if there is some issue with Sunshine or the scripts - during development and testing I hit quite a few of those cases; I'm confident it shouldn't happen during normal operation anymore, but just in case it does, you can escape in a few ways:
+While I'm pretty confident this will not break your computer, I don't know enough about Windows Drivers to be 100% sure.  Further, there is a **real risk** that your displays won't come back after a streaming sesion if there is some issue with Sunshine or the scripts - during development and testing I hit quite a few of those cases; I'm confident it shouldn't happen during normal operation anymore, but just in case it does, you can escape in a few ways:
 
 - If your displays don't come back, but sunshine is still running, you can get back in the stream and fix things up:
-    - Disable the display device - you can run the command `pnputil /disable-device /deviceid root\iddsampledriver` from a privileged terminal.  If you want to be extra secure you can try to bind this to some key combination ahead of time (make sure it runs as admin).
+    - Run this command from a privileged terminal to disable the virtual display.
+    ```batch
+    pnputil /disable-device /deviceid root\iddsampledriver
+    ```
+
+> [!NOTE]
+> If you want to be extra secure you can try to bind this command to some key combination ahead of time (make sure it runs as admin).
+>
+> To do this, create a new shortcut on Desktop (`Right Click` > `New` > `Shortcut`) and copy/paste the command above (`pnputil /disable-device /deviceid root\iddsampledriver`) in the path box.
+>
+> Give it a name like `Disable Virtual Display Driver` and close the window. Now go to the file properties and click in the `Shortcut Key` area, then enter a combination of keys to create the shortcut. (e.g. `Ctrl` + `Alt` + `5`)
+>
+> Open the `Advanced...` box and check the `Run as administrator` checkbox.
+>
+> Save and close.
+
 - If you can't access the sunshine stream for whatever reason, you can try a couple of things:
-    - Pres windows key + write "terminal" + press Enter + write "DisplaySwitch 1" + press Enter.  This should enable only your primary display, which should not be the virtual monitor, allowing you to fix things up.
-    - Press windows + P to get into the display selection dialogue, then tab + move around to select something different from the current setup.  I recommend practicing this ahead of time if you want to go this route, just so you have an idea of what it feels like; in the broken case it should have the "second screen only" option pre-selected.
+    - Open a Windows Terminal and run this command:
+    ```batch
+    DisplaySwitch 1
+    ```
+
+> [!NOTE]
+> This should enable only your primary display, which should not be the virtual monitor, allowing you to fix things up.
+
+-
+    - Press `Windows + P` to get into the display selection dialogue, then press `Tab` + move around to select something different from the current setup. I recommend practicing this ahead of time if you want to go this route, just so you have an idea of what it feels like; in the broken case it should have the "second screen only" option pre-selected.
+    
     - Connect another display to your computer - this will cause windows to try and apply a new configuration to the displays that should get signal on at least one of the real ones.
+    
     - If you already have a second monitor, disconnect it - similar to the point above, might result in getting signal back.
 
-## Dependencies
+## Setup
+
+First, download the [latest release](https://github.com/LeGeRyChEeSe/sunshine-virtual-monitor/releases/latest) (`.zip` file) and unzip it.
 
 ### Virtual Display Driver
 
-First, you'll need to add a virtual display to your computer.  You can follow the directions from [Virtual Display Driver](https://github.com/itsmikethetech/Virtual-Display-Driver?tab=readme-ov-file#virtual-display-driver) - afaict, this is the only way to get HDR support on a virtual monitor.  Note: while the driver and device will exist, they will be disabled while sunshine isn't being used.
+Then, you'll need to add a virtual display to your computer.  You can follow the directions from [Virtual Display Driver](https://github.com/itsmikethetech/Virtual-Display-Driver?tab=readme-ov-file#virtual-display-driver) - afaict, this is the only way to get HDR support on a virtual monitor.  Note: while the driver and device will exist, they will be disabled while sunshine isn't being used.
 
 Once you're done adding the device, make sure to disable it.  You can do this in device manager, or you can run the following command in an administrator terminal:
 
-```
+```batch
 pnputil /disable-device /deviceid root\iddsampledriver
 ```
 
-Note: the resolutions supported by the driver are listed in a file called `options.txt`, and are read when the driver is setup.  This file has a decent collection of resolutions and refresh rates, but it might be fairly incomplete - in particular, it doesn't necessarily list many common phone resolutions, and it lacks higher refresh rates for resolutions other than 1080p.  I recommend going through your client devices and figuring out which resolutions and refresh rates they have, and adding those to the `options.txt` file (or making an `options.txt` file with only those resolutions so it's easier to navigate) before installing the driver.  If you need to add resolutions in the future, you would simply uninstall the driver, edit the `options.txt` file, and reinstall the driver - this is a relatively easy and quick process that is documented in the driver repository. I would also recommend setting up the supported resolutions in sunshine to match those of the `options.txt` file.
+> [!NOTE]
+> Make sure the `C:\IddSampleDriver\option.txt` file exists (create it if it doesn't).
+>
+> Open the file with notepad and write `1`, add a new line, save and close.
+>
+> The custom resolutions/frame rates of your clients will automatically be updated in the file.
 
 ### Multi Monitor Tool
 
 Then, you'll need to download [MultiMonitorTool](https://www.nirsoft.net/utils/multi_monitor_tool.html) - make sure to place the extracted files in the same directory as the scripts.  These scripts assume that the multi-monitor-tool in use is the 64-bit version - if you need the 32 bit version, you'll need to edit this line for the correct path:
 
-```
+```batch
 $multitool = Join-Path -Path $filePath -ChildPath "multimonitortool-x64\MultiMonitorTool.exe"
 ```
 
@@ -42,7 +88,7 @@ $multitool = Join-Path -Path $filePath -ChildPath "multimonitortool-x64\MultiMon
 
 The powershell scripts use a module called [`WindowsDisplayManager`](https://github.com/patrick-theprogrammer/WindowsDisplayManager) - you can install this by starting a privileged powershell, and running:
 
-```
+```batch
 Install-Module -Name WindowsDisplayManager
 ```
 
@@ -56,7 +102,8 @@ Just download [vsync-toggle](https://github.com/xanderfrangos/vsync-toggle/relea
 
 In all the text below, replace `%PATH_TO_THIS_REPOSITORY%` with the full path to this repository.
 
-Note that the commands below will forward the scripts output to a file in this repository, named `sunvdm.log` - this is optional and can be removed if you don't care for logs / can be directed somewhere else.
+> [!NOTE]
+> The commands below will forward the scripts output to a file in this repository, named `sunvdm.log` - this is optional and can be removed if you don't care for logs / can be directed somewhere else.
 
 ### UI
 
@@ -66,26 +113,31 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 
 In the first text box the `config.do_cmd` column, you will write:
 
-```
+```batch
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
-```
+```batch
 cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
-Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
+> [!WARNING]
+> Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
+>
+> Make sure also to replace `%PATH_TO_THIS_REPOSITORY%` with the correct path to the folder containing the scripts.
 
-You will also select the checkbox for `config.elevated` under the `config.run_as` column (we need to run as elevated in order to enable and disable the display device).
+> [!NOTE]
+> You will also select the checkbox for `config.elevated` under the `config.run_as` column (we need to run as elevated in order to enable and disable the display device).
 
 ### Config File
 
 You can set the following in your `sunshine.conf` config file:
 
-```
+```batch
 global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
 ```
 
-If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.
+> [!NOTE]
+> If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ While I'm pretty confident this will not break your computer, I don't know enoug
 
 ## Setup
 
-First, download the [latest release](https://github.com/LeGeRyChEeSe/sunshine-virtual-monitor/releases/latest) (`.zip` file) and unzip it.
+First, download the [latest release](https://github.com/Cynary/sunshine-virtual-monitor/releases/latest) (`.zip` file) and unzip it.
 
 
 ### Virtual Display Driver

--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 In the first text box the `config.do_cmd` column, you will write:
 
 ```
-cmd /C powershell.exe -File %PATH_TO_THIS_REPOSITORY%\setup_sunvdm.ps1 %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% > %PATH_TO_THIS_REPOSITORY%\sunvdm.log 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
 ```
-cmd /C powershell.exe -File %PATH_TO_THIS_REPOSITORY%\teardown_sunvdm.ps1 >> %PATH_TO_THIS_REPOSITORY%\sunvdm.log 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1
 ```
+
+Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)
 
 You will also select the checkbox for `config.elevated` under the `config.run_as` column (we need to run as elevated in order to enable and disable the display device).
 
@@ -83,7 +85,7 @@ You will also select the checkbox for `config.elevated` under the `config.run_as
 You can set the following in your `sunshine.conf` config file:
 
 ```
-global_prep_cmd = [{"do":"cmd /C powershell.exe -File %PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1 %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","undo":"cmd /C powershell.exe -File %PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1 >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","elevated":"true"}]
+global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%"" > %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" %VDD_NAME% >> %PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1","elevated":"true"}]
 ```
 
 If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ At the bottom, in the `Command Preparations` section, you will press the `+Add` 
 In the first text box the `config.do_cmd` column, you will write:
 
 ```
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\setup_sunvdm.ps1" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% "%VDD_NAME%" > "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
 In the second text box, the `config.undo_cmd` column, you will write:
 
 ```
-cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\\sunvdm.log" 2>&1
+cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file "%PATH_TO_THIS_REPOSITORY%\teardown_sunvdm.ps1" "%VDD_NAME%" >> "%PATH_TO_THIS_REPOSITORY%\sunvdm.log" 2>&1
 ```
 
 Make sure to replace `%VDD_NAME%` from both commands with the name of the Virtual Display Driver name (e.g.: IddSampleDriver Device HDR)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You will also select the checkbox for `config.elevated` under the `config.run_as
 You can set the following in your `sunshine.conf` config file:
 
 ```
-global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\"" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log 2>&1\"","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\"" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
+global_prep_cmd = [{"do":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\setup_sunvdm.ps1\" %SUNSHINE_CLIENT_WIDTH% %SUNSHINE_CLIENT_HEIGHT% %SUNSHINE_CLIENT_FPS% %SUNSHINE_CLIENT_HDR% \"%VDD_NAME%\" > \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","undo":"cmd /C powershell.exe -executionpolicy bypass -windowstyle hidden -file \"%PATH_TO_THIS_REPOSITORY%\\teardown_sunvdm.ps1\" \"%VDD_NAME%\" >> \"%PATH_TO_THIS_REPOSITORY%\\sunvdm.log\" 2>&1","elevated":"true"}]
 ```
 
 If you already have something in the `global_prep_cmd` that you setup, you should be savvy enough to know where/how to add this to the list.

--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -1,10 +1,12 @@
 Import-Module WindowsDisplayManager
 
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+
 # Snapshot the current display state so we can restore it after the session.
 #
 if ($args.Length -lt 4)
 {
-    Throw "Incorrect number of args: should pass WIDTH HEIGHT REFRESH_RATE HDR{0|1}"
+    Throw "Incorrect number of args: should pass WIDTH HEIGHT REFRESH_RATE HDR{0|1} VDD_NAME"
 }
 
 $filePath = Split-Path $MyInvocation.MyCommand.source
@@ -28,10 +30,11 @@ $height = [int]$args[1]
 $refresh_rate = [int]$args[2]
 $hdr = $args[3] -eq "true"
 $hdr_string = if($hdr) { "on" } else { "off" }
+$vdd_name = if ($args[3] -ne "true" -and $args[3] -ne "false") { $args[3] } else { $args[4] }
 Write-Host "Setting up a moonlight monitor with $($width)x$($height)@$($refresh_rate) with hdr $($hdr_string)"
 
 Write-Host "Enabling the virtual display."
-pnputil /enable-device /deviceid root\iddsampledriver
+Get-PnpDevice -FriendlyName $vdd_name | Enable-PnpDevice -Confirm:$false
 
 $displays = WindowsDisplayManager\GetAllPotentialDisplays
 $multitool = Join-Path -Path $filePath -ChildPath "multimonitortool-x64\MultiMonitorTool.exe"
@@ -40,13 +43,13 @@ $multitool = Join-Path -Path $filePath -ChildPath "multimonitortool-x64\MultiMon
 #
 foreach ($display in $displays)
 {
-    if ($display.source.description -eq "IddSampleDriver Device HDR")
+    if ($display.source.description -eq $vdd_name)
     {
         $vdDisplay = $display
     }
 }
 
-$other_displays = $displays | Where-Object {$_.source.description -ne "IddSampleDriver Device HDR"}
+$other_displays = $displays | Where-Object {$_.source.description -ne $vdd_name}
 
 # First make sure the new virtual display is enabled, primary, and fully setup.
 #
@@ -79,7 +82,7 @@ while(($other_displays | ForEach-Object {WindowsDisplayManager\GetRefreshedDispl
 #
 $vdDisplay.SetResolution($width,$height,$refresh_rate)
 
-if ($vdDisplay.source.description -eq "IddSampleDriver Device HDR")
+if ($vdDisplay.source.description -eq $vdd_name -and ${WindowsDisplayManager\GetRefreshedDisplay($displays[0]).hdrInfo.hdrSupported})
 {
     # This is a bit of a hack - due to https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/1 and https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/2, the HDR controls for the virtual display are actually in the first display via WindowsDisplayManager; it's also the reason we needed a different tool to enable/disable the displays despite iterating through the output of WindowsDisplayManager.
     #

--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -30,7 +30,25 @@ $height = [int]$args[1]
 $refresh_rate = [int]$args[2]
 $hdr = $args[3] -eq "true"
 $hdr_string = if($hdr) { "on" } else { "off" }
-$vdd_name = if ($args[3] -ne "true" -and $args[3] -ne "false") { $args[3] } else { $args[4] }
+
+Write-Output "hdr = $hdr_string"
+
+# + Choose the exact name of the Virtual Monitor to allow different versions without breaking the script.
+$vdd_name = $args[4]
+
+# + Add the feature of auto resolution/frame rate without the need of adding them manually in option.txt
+$option_to_check = "$width, $height, $refresh_rate"
+$option_file_path = "C:\IddSampleDriver\option.txt"
+$option_file_content = Get-Content -Path $option_file_path
+
+# + Verify the resolution associated with frame rate is not already in the option.txt file
+if ($option_file_content -notcontains $option_to_check)
+{
+    # + Add the string to the end of the file
+    Add-Content -Path $option_file_path -Value $option_to_check
+    Write-Output "The new resolution/frame rate '$option_to_check' has been added to $option_file_path"
+}
+
 Write-Host "Setting up a moonlight monitor with $($width)x$($height)@$($refresh_rate) with hdr $($hdr_string)"
 
 Write-Host "Enabling the virtual display."
@@ -82,7 +100,7 @@ while(($other_displays | ForEach-Object {WindowsDisplayManager\GetRefreshedDispl
 #
 $vdDisplay.SetResolution($width,$height,$refresh_rate)
 
-if ($vdDisplay.source.description -eq $vdd_name -and ${WindowsDisplayManager\GetRefreshedDisplay($displays[0]).hdrInfo.hdrSupported})
+if ($vdDisplay.source.description -eq $vdd_name -and (WindowsDisplayManager\GetRefreshedDisplay($displays[0])).hdrInfo.hdrSupported)
 {
     # This is a bit of a hack - due to https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/1 and https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/2, the HDR controls for the virtual display are actually in the first display via WindowsDisplayManager; it's also the reason we needed a different tool to enable/disable the displays despite iterating through the output of WindowsDisplayManager.
     #

--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -4,7 +4,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
 # Snapshot the current display state so we can restore it after the session.
 #
-if ($args.Length -lt 4)
+if ($args.Length -lt 5)
 {
     Throw "Incorrect number of args: should pass WIDTH HEIGHT REFRESH_RATE HDR{0|1} VDD_NAME"
 }

--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -41,6 +41,24 @@ $option_to_check = "$width, $height, $refresh_rate"
 $option_file_path = "C:\IddSampleDriver\option.txt"
 $option_file_content = Get-Content -Path $option_file_path
 
+# + Check if the file exists
+if (-Not (Test-Path -Path $option_file_path))
+{
+    $directory = [System.IO.Path]::GetDirectoryName($option_file_path)
+    
+    Write-Host "Creating $option_file_path..."
+
+    # + Check if the folder exists, otherwise create it
+    if (-Not (Test-Path -Path $directory))
+    {
+        # + Create the folder
+        New-Item -Path $directory -ItemType Directory -Force
+    }
+
+    # + Create the file and write 1 in it
+    Set-Content -Path $option_file_path -Value "1"
+}
+
 # + Verify the resolution associated with frame rate is not already in the option.txt file
 if ($option_file_content -notcontains $option_to_check)
 {

--- a/teardown_sunvdm.ps1
+++ b/teardown_sunvdm.ps1
@@ -1,9 +1,18 @@
 Import-Module WindowsDisplayManager
 
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+
+if ($args.Length -lt 1)
+{
+    Throw "Incorrect number of args: should pass VDD_NAME"
+}
+
+$vdd_name = $args[0]
+
 # Might not work well if you have more than one GPU with displays attached. See https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/1
 #
 Write-Host "Removing the moonlight display."
-pnputil /disable-device /deviceid root\iddsampledriver
+Get-PnpDevice -FriendlyName $vdd_name | Disable-PnpDevice -Confirm:$false
 
 $filePath = Split-Path $MyInvocation.MyCommand.source
 $displayStateFile = Join-Path -Path $filePath -ChildPath "display_state.json"

--- a/teardown_sunvdm.ps1
+++ b/teardown_sunvdm.ps1
@@ -2,12 +2,9 @@ Import-Module WindowsDisplayManager
 
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
-if ($args.Length -lt 1)
-{
-    Throw "Incorrect number of args: should pass VDD_NAME"
-}
 
-$vdd_name = $args[0]
+# + Choose the exact name of the Virtual Monitor to allow different versions without breaking the script.
+$vdd_name = (Get-PnpDevice -Class Display | Where-Object {$_.FriendlyName -like "*idd*" -or $_.FriendlyName -like "*mtt*"}).FriendlyName
 
 # Might not work well if you have more than one GPU with displays attached. See https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/1
 #


### PR DESCRIPTION
I have added a variable required in the `do_cmd` and `undo_cmd` named `VDD_NAME` and it's retrieved by the script automatically to get the correct display.

Now you can install either VDD for Windows 10 (No HDR) or VDD for Windows 11 (HDR) and run the script.

Edit:
I forgot to mention, but the patch also fixed the issue with cold reboots. The script will work in any case now.