### PR TITLE
Update setup_sunvdm.ps1

### DIFF
--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -13,6 +13,9 @@ $displayStateFile = Join-Path -Path $filePath -ChildPath "display_state.json"
 $stateFile = Join-Path -Path $filePath -ChildPath "state.json"
 $vsynctool = Join-Path -Path $filePath -ChildPath "vsynctoggle-1.1.0-x86_64.exe"
 $state = @{ 'vsync' = & $vsynctool status }
+if ($state['vsync'] -like '*default*') {
+    $state['vsync'] = 'default'
+}
 
 $initial_displays = WindowsDisplayManager\GetAllPotentialDisplays
 if (! $(WindowsDisplayManager\SaveDisplaysToFile -displays $initial_displays -filePath $displayStateFile)) {


### PR DESCRIPTION
Fix for the case where the vsync configuration is default. The tool returns 2 strings .\vsynctoggle-1.1.0-x86_64.exe status
app
default

which is translated to app, default, which is an invalid option for the tool.