### PR TITLE
FIX: Match virtual monitor with no HDR

### DIFF
--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -38,7 +38,7 @@ $vdd_name = (
     Where-Object {
         $_.FriendlyName -like "*idd*" -or
         $_.FriendlyName -like "*mtt*" -or
-        $_.FriendlyName -like "Virtual Display with HDR"
+        $_.FriendlyName -like "Virtual Display*"
     })[0].FriendlyName
 
 # + Add the feature of auto resolution/frame rate without the need of adding them manually in option.txt

--- a/teardown_sunvdm.ps1
+++ b/teardown_sunvdm.ps1
@@ -9,7 +9,7 @@ $vdd_name = (
     Where-Object {
         $_.FriendlyName -like "*idd*" -or
         $_.FriendlyName -like "*mtt*" -or
-        $_.FriendlyName -like "Virtual Display with HDR"
+        $_.FriendlyName -like "Virtual Display*"
     })[0].FriendlyName
 
 # Might not work well if you have more than one GPU with displays attached. See https://github.com/patrick-theprogrammer/WindowsDisplayManager/issues/1


### PR DESCRIPTION
Tested with #19, but I'm not sure if #19 is necessary. Should still match all friendly names that were matched before, but also matches my virtual monitor with FriendlyName `Virtual DIsplay Driver`.
