### PR TITLE
Remove not enabled monitors from list of displays to disable

### DIFF
--- a/setup_sunvdm.ps1
+++ b/setup_sunvdm.ps1
@@ -86,7 +86,7 @@ foreach ($display in $displays) {
     }
 }
 
-$other_displays = $displays | Where-Object { $_.source.description -ne $vdd_name }
+$other_displays = $displays | Where-Object { $_.source.description -ne $vdd_name -and $_.Enabled }
 
 # First make sure the new virtual display is enabled, primary, and fully setup.
 #


### PR DESCRIPTION
My display manager gave the following 

`PS C:\Program Files\WindowsPowerShell\Modules\WindowsDisplayManager\1.1.1\structures> WindowsDisplayManager\GetAllPotentialDisplays

Display ID   Description            Active  Enabled  Primary  Resolution           HDR Info               Position   Recommended
                                                                                                                     Resolution
----------   -----------            ------  -------  -------  ----------           --------               --------   ------------------
0-256        IDD HDR via NVIDIA     True    True     False    Width       : 5120   HdrSupported : True    X : -5120  Width  : 1280
             GeForce RTX 3080 Ti                              Height      : 1440   HdrEnabled   : False   Y : 0      Height : 800
                                                              RefreshRate : 240    BitDepth     : 10
1            Unconnected NVIDIA     False   False    False    N/A                  N/A                    N/A        N/A
             GeForce RTX 3080 Ti
             source
2            Unconnected NVIDIA     False   False    False    N/A                  N/A                    N/A        N/A
             GeForce RTX 3080 Ti
             source
3            Unconnected NVIDIA     False   False    False    N/A                  N/A                    N/A        N/A
             GeForce RTX 3080 Ti`

This meant disabled screens were always checked and it would stay stuck in a loop. 

The change is removing disabled screens from the list of screen to disable. 